### PR TITLE
chore: update dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,11 +12,11 @@ keywords = ["socketio"]
 license = "MIT"
 
 [dependencies]
-redis = "0.21.2"
-rmp = "0.8.10"
-serde = "1.0.130"
-serde_derive = "1.0.130"
-rmp-serde = "0.15.5"
+redis = "0.27"
+rmp = "0.8"
+serde = "1.0"
+serde_derive = "1.0"
+rmp-serde = "1.3"
 
 [dev-dependencies]
-testcontainers = "0.12.0"
+testcontainers = { version = "0.22.0", features = ["blocking"] }


### PR DESCRIPTION
Fixes dependency resolution error with rmp-serde due to them yanking all 0.15.X versions